### PR TITLE
Adicionar fluxo de guia para um iniciante

### DIFF
--- a/bot/data/intents/begin.md
+++ b/bot/data/intents/begin.md
@@ -1,0 +1,36 @@
+## intent:fluxo_inicio
+- Como iniciar
+- Por onde começo
+- Começo
+- Iniciar
+- conteudo
+- ementa
+- Pra onde ir
+- To perdido
+- O que devo fazer
+- begin
+- start
+- fluxograma inicial
+- Como começar
+- Desejo saber por onde começar
+- Desejo saber por onde iniciar
+- começo
+- início
+
+## intent:preprocessamento_topicos
+- Pre-processamento de dados
+- Pre-processamento
+- preprocessamento
+- preparação de dados
+
+## intent:modelagem_topicos
+- Modelos de treinamento
+- modelagem de dados
+- aprendizado supervisionado
+- aprendizado não supervisionado
+- Quais modelos devo usar
+
+## intent:visualizacao_topicos
+- Visualização
+- Visualização de dados
+- Como visualizar os dados

--- a/bot/data/stories/begin.md
+++ b/bot/data/stories/begin.md
@@ -1,0 +1,33 @@
+## Como Iniciar
+* fluxo_inicio
+    - utter_listagem_conteudos
+* afirmar
+    - utter_preprocessamento_topicos
+
+## Pre processamento
+* preprocessamento_topicos
+    - utter_preprocessamento_topicos
+* afirmar
+    - utter_modelagem_topicos
+
+## Pre processamento 2
+* preprocessamento_topicos
+    - utter_preprocessamento_topicos
+* negar
+    - utter_bons_estudos    
+
+## Modelagem
+* modelagem_topicos
+    - utter_modelagem_topicos
+* afirmar
+    - utter_visualizacao_topicos
+
+## Modelagem 2
+* modelagem_topicos
+    - utter_modelagem_topicos
+* negar
+    - utter_bons_estudos
+
+## Visualizacao
+* visualizacao_topicos
+    - utter_visualizacao_topicos

--- a/bot/e2e/e2e_stories_begin.md
+++ b/bot/e2e/e2e_stories_begin.md
@@ -1,0 +1,19 @@
+## Stories for Pyter Test - 176
+* fluxo_inicio: Como iniciar?
+	 - utter_listagem_conteudosutter_preprocessamento_topicos
+* afirmar: Sim
+	 - utter_preprocessamento_topicos
+* preprocessamento_topicos: Pre-processamento
+	 - utter_modelagem_topicos
+* afirmar: Sim
+	 - utter_preprocessamento_topicos
+* preprocessamento_topicos: Pré-processamento
+	 - utter_bons_estudos
+* negar: Não
+	 - utter_modelagem_topicos
+* modelagem_topicos: Modelagem de dadossim
+	 - utter_visualizacao_topicosutter_modelagem_topicos
+* afirmar: ModelagemNao
+	 - utter_bons_estudos
+* modelagem_topicos: Visualização de dados
+	 - utter_visualizacao_topicos

--- a/bot/e2e/end-to-end-script-begin.py
+++ b/bot/e2e/end-to-end-script-begin.py
@@ -1,0 +1,76 @@
+"""
+End to end test script
+To add new test cases add the:
+    - user_intent
+    - user_input
+    - utter
+"""
+
+user_intent = [
+    'fluxo_inicio',
+    'afirmar',
+    'preprocessamento_topicos',
+    'afirmar',
+    'preprocessamento_topicos',
+    'negar',
+    'modelagem_topicos',
+    'afirmar',
+    'modelagem_topicos',
+    'negar',
+    'visualizacao_topicos'
+]
+
+user_input = [
+    'Como iniciar?',
+    'Sim',
+    'Pre-processamento',
+    'Sim',
+    'Pré-processamento',
+    'Não',
+    'Modelagem de dados'
+    'sim',
+    'Modelagem'
+    'Nao',
+    'Visualização de dados'
+]
+
+utter = [
+    'utter_listagem_conteudos'
+    'utter_preprocessamento_topicos',
+    'utter_preprocessamento_topicos',
+    'utter_modelagem_topicos',
+    'utter_preprocessamento_topicos',
+    'utter_bons_estudos',
+    'utter_modelagem_topicos',
+    'utter_visualizacao_topicos'
+    'utter_modelagem_topicos',
+    'utter_bons_estudos',
+    'utter_visualizacao_topicos'
+
+]
+
+
+def create_stories(user_intent, user_input, utter):
+    """
+    Zip through lists and return them in the e2e test format
+    """
+    for intent, inp, utt in zip(user_intent, user_input, utter):
+        yield "* {}: {}\n\t - {}".format(intent, inp, utt)
+
+
+def write_file(stories):
+    """
+    write story tests to file
+    """
+    E2E_FILE = './e2e_stories_begin.md'
+    title = "## Stories for Pyter Test - 176\n"
+
+    with open(E2E_FILE, "w") as f:
+        f.write(title)
+        stories = [story for story in stories]
+        for story in stories:
+            f.write("%s\n" % story)
+
+
+stories = create_stories(user_intent, user_input, utter)
+write_file(stories)


### PR DESCRIPTION
##Adicionar fluxo de guia para um iniciante

O bot precisa conseguir guiar um iniciante em um fluxo de aprendizagem para que ele entenda como o bot possa ajudar ele.

[Adicionar fluxo de guia para um iniciante](https://github.com/fga-eps-mds/2019.1-PyLearner/issues/190)

## Critério

Ex:
- [x] Testes criados.
- [x] testes passando.
- [x] build passando.

Resolva #61 .